### PR TITLE
bump analyzer version

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -16,8 +16,6 @@ linter:
     - avoid_classes_with_only_static_members
     - avoid_private_typedef_functions
     - avoid_redundant_argument_values
-    - avoid_returning_null
-    - avoid_returning_null_for_future
     - avoid_returning_this
     - avoid_unused_constructor_parameters
     - avoid_void_async

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: '>=2.19.0 <4.0.0'
 
 dependencies:
-  analyzer: ^5.2.0
+  analyzer: ^6.4.1
   build: ^2.0.0
   build_test: ^2.0.0
   dart_style: ^2.0.0


### PR DESCRIPTION
This PR just bumps the min constraint of `analyzer`, figured I'd upstream this change since I was hard-blocked by what was on `main`.